### PR TITLE
Additional Support for Master's Thesis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 main.pdf
 ~$*.*
 *.synctex(busy)
+pdfa.xmpi

--- a/ConcordiaU.sty
+++ b/ConcordiaU.sty
@@ -188,17 +188,17 @@ of Doctor of Philosophy.
     \begin{singlespace}
     \noindent \hspace*{3cm} \hrulefill \makebox[4cm][l]{ Chair} \\
     \hspace*{3cm} \raisebox{.1cm}{\makebox[4cm][l]{\it Dr. \@chairOfCommittee}} \\
+    \ifphd
     \newline 
     \hspace*{3cm} \hrulefill \makebox[4cm][l]{ External Examiner} \\
     \hspace*{3cm} \raisebox{.1cm}{\makebox[4cm][l]{\it Dr. \@examinerExternalOfCommittee}} \\
+    \fi
     \newline 
     \hspace*{3cm} \hrulefill \makebox[4cm][l]{ Examiner} \\
     \hspace*{3cm} \raisebox{.1cm}{\makebox[4cm][l]{\it Dr. \@examinerFirstOfCommittee}} \\
-    \ifphd%
     \newline 
     \hspace*{3cm} \hrulefill \makebox[4cm][l]{ Examiner} \\
     \hspace*{3cm} \raisebox{.1cm}{\makebox[4cm][l]{\it Dr. \@examinerSecondOfCommittee}} \\
-    \fi%
     \newline 
     \hspace*{3cm} \hrulefill \makebox[4cm][l]{ Supervisor}\\
     \hspace*{3cm} \raisebox{.1cm}{\makebox[4cm][l]{\it Dr. \@principaladvisor}} \\
@@ -305,7 +305,17 @@ of Doctor of Philosophy.
 \renewenvironment{abstract}
        {\ifphd\phdabstract\else\mastersabstract\fi}
        {}
+       
+\newenvironment{statement}
+        {\prefacesection{Statement of Originality}}
+
+\newenvironment{dedication}
+       {\prefacesection{Dedication}} 
 
 \newenvironment{acknowledgments}
        {\prefacesection{Acknowledgments}}
+
+\newenvironment{publications}
+       {\prefacesection{Related Submitted Publications}}
+
 \makeatother

--- a/ConcordiaU.sty
+++ b/ConcordiaU.sty
@@ -230,7 +230,6 @@ of Doctor of Philosophy.
 }
 
 \def\mastersabstract{%
-        \thispagestyle{empty}
         \newpage
         \null\vskip.25in%
         \begin{center}

--- a/Dedication.tex
+++ b/Dedication.tex
@@ -1,0 +1,5 @@
+\begin{dedication}
+
+    \rightline{\textit{Dedication Text}}
+    
+\end{dedication}

--- a/Publications.tex
+++ b/Publications.tex
@@ -1,0 +1,3 @@
+\begin{publications}
+    Text of publications.
+\end{publications}

--- a/Statement.tex
+++ b/Statement.tex
@@ -1,0 +1,3 @@
+\begin{statement}
+    Statement Text
+\end{statement}

--- a/main.tex
+++ b/main.tex
@@ -55,6 +55,7 @@
 %\usepackage{epsfig}					           % eps figures 
 %\usepackage{epstopdf}                           % eps to pdf print
 %\usepackage{multirow} 					          % multirow in a table cell
+\usepackage[a-1b]{pdfx}                         % To generate the pdf as a pdf/A required for final submission.
 
 %###################  END: Environment Setup  #######################
 
@@ -98,6 +99,9 @@
 \coverPage
 \signaturePage
 \include{Abstract}
+\include{Publications}
+\include{Statement}
+\include{Dedication}
 \include{Acknowledgements}
 \contentLists
 


### PR DESCRIPTION
Hi @suhaibmujahid,

I found that I needed to make a few additions to the template when writing my Thesis. I figured I would contribute them back to the template if you're interested.

- The template as is did not allow for a second examiner at the Master's level. I added support for this to have a 2nd internal examiner rather than an external one.
- Added templates for Statement of originality, dedication, and publications pages.
- Added support to export PDF with PDF/A Compliance for final submission
- Add the missing page number on the abstract which is required